### PR TITLE
Basic indexing support

### DIFF
--- a/AutoGenTool/Config.fs
+++ b/AutoGenTool/Config.fs
@@ -40,7 +40,7 @@ module Config =
     ]
 
     // include (*.h) files not (yet) supported
-    let SKIP_INCLUDES = ["compatible"; "cuda"; "features"; "graphics"; "image"; "index"; "opencl"; "vision" ]
+    let SKIP_INCLUDES = ["compatible"; "cuda"; "features"; "graphics"; "image"; "opencl"; "vision" ]
 
     // path to the ArrayFire library source code (relative to this project's bin/Debug or bin/Release folders)
     let OUTPUT_DIR = "../../../Wrapper"

--- a/AutoGenTool/ForInDo.fs
+++ b/AutoGenTool/ForInDo.fs
@@ -77,7 +77,7 @@ module ForInDo =
             if Regex.IsMatch(line, "^\s*#else") then
                 let addNewLine = function [one] -> [one] | many -> ""::many
                 let cutEmptyHead = function ""::rest -> rest | other -> other
-                let replaces = repls |> addNewLine |> listCartesian mats |> List.map (fun (m,r) -> replaceLU m patt r)
+                let replaces = repls |> addNewLine |> listCartesian mats |> List.map (fun (m,r) -> replaceLU patt r m)
                 processEnd rest ((cutEmptyHead replaces) @ (line::result))
             else processDo rest (line::result) patt mats (line::repls)
 

--- a/AutoGenTool/Utils.fs
+++ b/AutoGenTool/Utils.fs
@@ -42,7 +42,7 @@ module Utils =
     let listCartesian xlist ylist = xlist |> List.collect (fun x -> ylist |> List.map (fun y -> x,y))
 
     // a version of Regex.Replace that supports $Ux and $Lx as the uppercase and lowercase versions of $x where x is the group number (e.g. $U1 is the same as $1 but in lowercase)
-    let replaceLU input pattern replacement =
+    let replaceLU pattern replacement input =
         let mev (mat:Match) =
             let mutable res = mat.Result replacement
             for i = 1 to mat.Groups.Count - 1 do
@@ -65,3 +65,13 @@ module Utils =
     let saveLinesToFile (file:string) (lines:string list) =
         use sw = new StreamWriter(file, false)
         for line in lines do line.TrimEnd() |> sw.WriteLine
+
+    type WordLocation = Anywhere | FirstWord | LastWord
+
+    let replaceWord loc oldword (newword:string) input =
+        let pat = 
+            match loc with
+            | Anywhere -> @"\b" + oldword + @"\b"
+            | FirstWord -> "^" + oldword + @"\b"
+            | LastWord -> @"\b" + oldword + "$"
+        Regex.Replace(input, pat, newword)

--- a/Examples/HelloWorld/CSharp/Program.cs
+++ b/Examples/HelloWorld/CSharp/Program.cs
@@ -4,6 +4,10 @@ using System.Collections.Generic;
 
 using ArrayFire;
 
+// If using Visual Studio 2015 you can uncomment the following lines and type Sin() instead of Arith.Sin(), Seq() instead of Util.Seq(), and so on.
+// using static ArrayFire.Arith;
+// using static ArrayFire.Util;
+
 namespace CSharpTesting
 {
     class Program
@@ -21,6 +25,15 @@ namespace CSharpTesting
             Util.Print(arr3, "arr1 + arr2");
             Util.Print(arr4, "arr1 * arr2 (matrix product)");
             Util.Print(arr5, "Sin(arr1) + Cos(arr2)");
+
+            // new! indexing:    
+            Util.Print(arr1[Util.Span, 0], "arr1's first column");
+            Util.Print(arr1.Cols(0, 0), "arr1's first row (again)");
+            var corner = arr1[Util.Seq(0, 1), Util.Seq(0, 1)];
+            Util.Print(corner, "arr1's top-left 2x2 corner");
+            arr2[Util.Seq(1, 2), Util.Seq(1, 2)] = corner;
+            Util.Print(arr2, "arr2 with botton-right 2x2 corner ovewritten with the previous result");
+
         }
     }
 }

--- a/Examples/HelloWorld/FSharp/Program.fs
+++ b/Examples/HelloWorld/FSharp/Program.fs
@@ -21,4 +21,12 @@ let main argv =
     Util.Print(arr4, "arr1 * arr2 (matrix product)")
     Util.Print(arr5, "sin(arr1) + cos(arr2)");
 
+    // new! indexing:    
+    Util.Print(arr1.[Util.Span, Util.Seq(0,0)], "arr1's first column");
+    Util.Print(arr1.Cols(0, 0), "arr1's first row (again)");
+    let corner = arr1.[Util.Seq(0, 1), Util.Seq(0, 1)]
+    Util.Print(corner, "arr1's top-left 2x2 corner")
+    arr2.[Util.Seq(1, 2), Util.Seq(1, 2)] <- corner
+    Util.Print(arr2, "arr2 with botton-right 2x2 corner ovewritten with the previous result");
+
     0 // return an integer exit code

--- a/README.md
+++ b/README.md
@@ -27,12 +27,10 @@ Contents
 Usage
 ----------------
 
-- TODO
+- Refer to the Examples folder.
 
 Documentation
 ---------------
-- TODO
 
-License
----------------
-- TODO
+- In progress.
+

--- a/Wrapper/ArrayFire.csproj
+++ b/Wrapper/ArrayFire.csproj
@@ -47,11 +47,12 @@
     <Compile Include="Interop\AFBlas.cs" />
     <Compile Include="Interop\AFData.cs" />
     <Compile Include="Interop\AFDevice.cs" />
+    <Compile Include="Interop\AFIndex.cs" />
     <Compile Include="Interop\AFLapack.cs" />
     <Compile Include="Interop\AFSignal.cs" />
     <Compile Include="Interop\AFStatistics.cs" />
     <Compile Include="Interop\AFUtil.cs" />
-    <Compile Include="Interop\Enums.cs" />
+    <Compile Include="Interop\types.cs" />
     <Compile Include="enums.cs" />
     <Compile Include="Matrix.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Wrapper/Data.cs
+++ b/Wrapper/Data.cs
@@ -56,137 +56,137 @@ namespace ArrayFire
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Array CreateArray($2[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.$1)); return new Array(ptr); }
 #else
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(bool[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.b8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(bool[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.b8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(bool[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.b8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(bool[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.b8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(bool[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.b8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(bool[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.b8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(bool[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.b8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(bool[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.b8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(Complex[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.c64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(Complex[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.c64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(Complex[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.c64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(Complex[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.c64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(Complex[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.c64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(Complex[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.c64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(Complex[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.c64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(Complex[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.c64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(float[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.f32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(float[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.f32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(float[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.f32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(float[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.f32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(float[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.f32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(float[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.f32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(float[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.f32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(float[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.f32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(double[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.f64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(double[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.f64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(double[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.f64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(double[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.f64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(double[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.f64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(double[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.f64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(double[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.f64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(double[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.f64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(int[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.s32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(int[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.s32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(int[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.s32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(int[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.s32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(int[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.s32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(int[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.s32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(int[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.s32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(int[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.s32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(long[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.s64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(long[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.s64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(long[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.s64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(long[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.s64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(long[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.s64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(long[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.s64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(long[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.s64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(long[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.s64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(uint[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(uint[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(uint[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(uint[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(uint[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(uint[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(uint[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(uint[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ulong[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ulong[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ulong[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ulong[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ulong[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ulong[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ulong[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ulong[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(byte[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(byte[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(byte[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(byte[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(byte[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(byte[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(byte[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(byte[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(short[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.s16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(short[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.s16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(short[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.s16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(short[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.s16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(short[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.s16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(short[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.s16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(short[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.s16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(short[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.s16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ushort[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ushort[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ushort[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ushort[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ushort[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ushort[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ushort[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ushort[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u16)); return new Array(ptr); }
 #endif
 		#endregion
 
@@ -207,137 +207,137 @@ namespace ArrayFire
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteArray(Array arr, $2[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 #else
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, bool[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, bool[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, bool[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, bool[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, bool[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, bool[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, bool[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, bool[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, Complex[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, Complex[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, Complex[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, Complex[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, Complex[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, Complex[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, Complex[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, Complex[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, float[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, float[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, float[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, float[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, float[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, float[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, float[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, float[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, double[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, double[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, double[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, double[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, double[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, double[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, double[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, double[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, int[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, int[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, int[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, int[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, int[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, int[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, int[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, int[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, long[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, long[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, long[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, long[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, long[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, long[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, long[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, long[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, uint[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, uint[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, uint[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, uint[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, uint[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, uint[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, uint[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, uint[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ulong[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ulong[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ulong[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ulong[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ulong[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ulong[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ulong[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ulong[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, byte[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, byte[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, byte[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, byte[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, byte[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, byte[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, byte[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, byte[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, short[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, short[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, short[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, short[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, short[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, short[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, short[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, short[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ushort[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ushort[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ushort[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ushort[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ushort[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ushort[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ushort[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ushort[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 #endif
 		#endregion
 
@@ -506,6 +506,16 @@ namespace ArrayFire
 			Internal.VERIFY(AFArith.af_cast(out ptr, arr._ptr, Internal.toDType<X>()));
 			return new Array(ptr);
 		}
-		#endregion
-	}
+        #endregion
+
+        #region Copying 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array Copy(Array arr)
+        {
+            IntPtr ptr;
+            Internal.VERIFY(AFArray.af_copy_array(out ptr, arr._ptr));
+            return new Array(ptr);
+        }
+        #endregion
+    }
 }

--- a/Wrapper/Interop/AFIndex.cs
+++ b/Wrapper/Interop/AFIndex.cs
@@ -1,0 +1,52 @@
+// This file was automatically generated using the AutoGenTool project
+// If possible, edit the tool instead of editing this file directly
+
+using System;
+using System.Text;
+using System.Numerics;
+using System.Security;
+using System.Runtime.InteropServices;
+
+namespace ArrayFire.Interop
+{
+	[SuppressUnmanagedCodeSecurity]
+	public static class AFIndex
+	{
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_index(out IntPtr array_out, IntPtr array_in, uint ndims, [In] af_seq[] index);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_lookup(out IntPtr array_out, IntPtr array_in, IntPtr array_indices, uint dim);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_assign_seq(ref IntPtr array_out, IntPtr array_lhs, uint ndims, [In] af_seq[] indices, IntPtr array_rhs);
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_index_gen(out IntPtr array_out, IntPtr array_in, long dim_ndims, ???const ???af_index_t???* indices???); */
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_assign_gen(out IntPtr array_out, IntPtr array_lhs, long dim_ndims, ???const ???af_index_t???* indices???, IntPtr array_rhs); */
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_indexers(??????af_index_t???** indexers???); */
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_set_array_indexer(out ???af_index_t??? indexer, IntPtr array_idx, long dim_dim); */
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_set_seq_indexer(out ???af_index_t??? indexer, [In] af_seq[] idx, long dim_dim, bool is_batch); */
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_set_seq_param_indexer(out ???af_index_t??? indexer, double begin, double end, double step, long dim_dim, bool is_batch); */
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_release_indexers(out ???af_index_t??? indexers); */
+	}
+}

--- a/Wrapper/Interop/types.cs
+++ b/Wrapper/Interop/types.cs
@@ -14,7 +14,28 @@ namespace ArrayFire.Interop
 		internal const string dll = @"af";
 	}
 
-	public enum af_err
+    [StructLayout(LayoutKind.Sequential)]
+    public struct af_seq
+    {
+        public af_seq(double begin, double end, double step)
+        {
+            this.begin = begin;
+            this.end = end;
+            this.step = step;
+        }
+
+        // the C-API uses doubles so we have to do the same
+        public double begin;
+        public double end;
+        public double step;
+
+        public static readonly af_seq Span = new af_seq(1, 1, 0); // as defined in include/af/seq.h
+
+        // implicit conversion from a number, only works in C# (not in F#)
+        public static implicit operator af_seq(double begin) { return new af_seq(begin, begin, 1); }
+    }
+
+    public enum af_err
 	{
 		///
 		/// The function returned successfully

--- a/Wrapper/Util.cs
+++ b/Wrapper/Util.cs
@@ -51,6 +51,20 @@ namespace ArrayFire
 		{
 			Internal.VERIFY(AFUtil.af_print_array_gen(name, arr._ptr, precision));
 		}
-		#endregion
-	}
+        #endregion
+
+        #region Sequences
+        public static readonly af_seq Span = af_seq.Span; // for convenience
+
+        public static af_seq Seq(double begin, double end, double step = 1)
+        {
+            return new af_seq(begin, end, step);
+        }
+
+        public static af_seq Seq(int begin, int end, int step = 1)
+        {
+            return new af_seq(begin, end, step);
+        }
+        #endregion
+    }
 }


### PR DESCRIPTION
Summary:

The *HelloWorld* examples have a few new lines showing the indexing functionality for both C# and F#

**Array.cs**: has a new indexing operator **[]**
**Util.cs**: new **Seq()** and **Span** members
**Data.cs**: new **Copy()** method (which was missing)

Inside the *Interop* folder there's a new file (**AFIndex.cs**), **enums.cs** got renamed to **types.cs** and it has a new class (**af_seq**).

*AutoGenTool* changes can be pretty much ignored since they are only for development purposes (code/interop generation).