### PR TITLE
Basic Indexing Support

### DIFF
--- a/AutoGenTool/Config.fs
+++ b/AutoGenTool/Config.fs
@@ -40,9 +40,7 @@ module Config =
     ]
 
     // include (*.h) files not (yet) supported
-    let SKIP_INCLUDES = ["compatible"; "cuda"; "features"; "graphics"; "image"; "index"; "opencl"; "vision" ]
+    let SKIP_INCLUDES = ["compatible"; "cuda"; "features"; "graphics"; "image"; "opencl"; "vision" ]
 
     // path to the ArrayFire library source code (relative to this project's bin/Debug or bin/Release folders)
     let OUTPUT_DIR = "../../../Wrapper"
-
-    let DLL_NAME = "af" // unified backend

--- a/AutoGenTool/ForInDo.fs
+++ b/AutoGenTool/ForInDo.fs
@@ -77,7 +77,7 @@ module ForInDo =
             if Regex.IsMatch(line, "^\s*#else") then
                 let addNewLine = function [one] -> [one] | many -> ""::many
                 let cutEmptyHead = function ""::rest -> rest | other -> other
-                let replaces = repls |> addNewLine |> listCartesian mats |> List.map (fun (m,r) -> replaceLU m patt r)
+                let replaces = repls |> addNewLine |> listCartesian mats |> List.map (fun (m,r) -> replaceLU patt r m)
                 processEnd rest ((cutEmptyHead replaces) @ (line::result))
             else processDo rest (line::result) patt mats (line::repls)
 

--- a/AutoGenTool/Interop.fs
+++ b/AutoGenTool/Interop.fs
@@ -1,4 +1,4 @@
-﻿(*
+﻿    (*
 Copyright (c) 2015, ArrayFire
 Copyright (c) 2015, Steven Burns (royalstream@hotmail.com)
 All rights reserved.
@@ -43,16 +43,10 @@ open Utils
 // generate the /ArrayFire/Interop/*.cs classes
 module Interop =
 
-    let private fixTypes str =
-        [   "unsigned",     "uint";
-            "intl",         "long";
-            "uintl",        "ulong"
-        ] |> List.fold (fun s x -> Regex.Replace(s, @"\b" + (fst x) + @"\b", snd x)) str
-
-    let private fixParamName str =
-        [   "in",   "input";
-            "out",  "output"
-        ] |> List.fold (fun s x -> Regex.Replace(s, @"\b" + (fst x) + "$", snd x)) str // "$" to anchor to the end
+    let private fixTypes =
+        replaceWord Anywhere "unsigned" "uint" >> 
+        replaceWord Anywhere "intl" "long" >> 
+        replaceWord Anywhere "uintl" "ulong"
 
     let private transformParameter (param:string) =
         let ismatch pat = Regex.IsMatch(param, "^" + pat + "$")
@@ -64,6 +58,7 @@ module Interop =
                 "(?:const\s+)?af_array\s+(\w+)",                "IntPtr array_$1";
                 // array inputs:
                 "const\s+af_array\s*\*\s*(?:const\s+)?(\w+)",   "[In] IntPtr[] array_$1";
+                "const\s+af_seq\s*\*\s*(?:const\s+)?(\w+)",     "[In] af_seq[] $1";
                 "const\s+dim_t\s*\*\s*(?:const\s+)?(\w+)",      "[In] long[] dim_$1";
                 "const\s+void\s*\*\s*(?:const\s+)?(\w+)",       "[In] T[_] $1"
                 "const\s+char\s*\*\s*(?:const\s+)?(\w+)",       "string $1";
@@ -81,8 +76,16 @@ module Interop =
                 // trivial-case outputs:
                 "(\w+)\s*\*\s*(\w+)",                           "out $1 $2";
             ] |> List.tryFind (fst >> ismatch) with
-        | Some (pat, rep) -> Regex.Replace(param, pat, rep) |> fixParamName
+        | Some (pat, rep) -> 
+            Regex.Replace(param, pat, rep) 
+            |> replaceWord LastWord "in" "input"
+            |> replaceWord LastWord "out" "output"
         | None -> "???" + param + "???"
+
+    let private finalFixes api str =
+        if api = "af_assign_seq" then replaceWord FirstWord "out" "ref" str
+        else if str.Contains("af_index_t") && not (str.Contains "???") then replaceWord Anywhere "af_index_t" "???af_index_t???" str
+        else str
 
     let private getFileMatches (file:string) =
         let matches =
@@ -92,7 +95,7 @@ module Interop =
             for mat in matches do
                 let apiname = mat.Groups.[1].Value
                 let parcaps = mat.Groups.[2].Captures
-                yield apiname, [ for cap in parcaps -> cap.Value.Trim() |> fixTypes |> transformParameter ] |> String.concat ", "
+                yield apiname, [ for cap in parcaps -> cap.Value.Trim() |> fixTypes |> transformParameter |> finalFixes apiname ] |> String.concat ", "
         } |> Seq.toList // lazy -> eager (release regex/match resources)
 
     let private getEnums (file:string) =
@@ -113,14 +116,11 @@ module Interop =
         let root = INCLUDE_DIR |> List.find Directory.Exists
 
         do
-            use cw = new CodeWriter(OUTPUT_DIR + "/Interop/Enums.cs")
-            cw <=- "internal static class af_config // put here for convenience"
-            cw <=- "{"
-            cw <=- "internal const string dll = @\"" + DLL_NAME + "\";"
-            cw <=- "}"
+            use cw = new CodeWriter(OUTPUT_DIR + "/Interop/enums.cs")
+            let mutable is1st = true
             Console.WriteLine "Enumerations:"
             for enum in getEnums (root + "/defines.h") do
-                cw <=- ""
+                if is1st then is1st <- false else cw <=- ""
                 cw <=- "public enum " + (fst enum)
                 cw <=- "{"
                 for value in snd enum do cw <=- value
@@ -146,20 +146,19 @@ module Interop =
                 cw <=- "{"
                 let mutable is1st = true
                 for api, pars in matches do
-                    let unsupp = pars.Contains("???")
+                    let unsupported = pars.Contains("???")
                     let versions =
-                        if not unsupp && pars.Contains("T[_]") then
-                            let add x y = y + x
+                        if not unsupported && pars.Contains("T[_]") then
                             [ "bool"; "Complex"; "float"; "double"; "int"; "long"; "uint"; "ulong"; "byte"; "short"; "ushort" ]
                             |> listCartesian [ "[]"; "[,]"; "[,,]"; "[,,,]" ]
                             |> List.map (fun (x,y) -> pars.Replace("T[_]", y + x))
                         else [ pars ]
                     for vpars in versions do
                         if is1st then is1st <- false else cw <=- ""
-                        if unsupp then cw <=- "/* not yet supported:"
+                        if unsupported then cw <=- "/* not yet supported:"
                         else Console.WriteLine (" + " + api)
                         cw <=- "[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]"
-                        cw <=- "public static extern af_err " + api + "(" + vpars + ");" + (if unsupp then " */" else "")
+                        cw <=- "public static extern af_err " + api + "(" + vpars + ");" + (if unsupported then " */" else "")
                 cw <=- "}"
                 Console.WriteLine()
 

--- a/AutoGenTool/Utils.fs
+++ b/AutoGenTool/Utils.fs
@@ -42,7 +42,7 @@ module Utils =
     let listCartesian xlist ylist = xlist |> List.collect (fun x -> ylist |> List.map (fun y -> x,y))
 
     // a version of Regex.Replace that supports $Ux and $Lx as the uppercase and lowercase versions of $x where x is the group number (e.g. $U1 is the same as $1 but in lowercase)
-    let replaceLU input pattern replacement =
+    let replaceLU pattern replacement input =
         let mev (mat:Match) =
             let mutable res = mat.Result replacement
             for i = 1 to mat.Groups.Count - 1 do
@@ -65,3 +65,13 @@ module Utils =
     let saveLinesToFile (file:string) (lines:string list) =
         use sw = new StreamWriter(file, false)
         for line in lines do line.TrimEnd() |> sw.WriteLine
+
+    type WordLocation = Anywhere | FirstWord | LastWord
+
+    let replaceWord loc oldword (newword:string) input =
+        let pat = 
+            match loc with
+            | Anywhere -> @"\b" + oldword + @"\b"
+            | FirstWord -> "^" + oldword + @"\b"
+            | LastWord -> @"\b" + oldword + "$"
+        Regex.Replace(input, pat, newword)

--- a/Examples/HelloWorld/CSharp/HelloWorld (CSharp).csproj
+++ b/Examples/HelloWorld/CSharp/HelloWorld (CSharp).csproj
@@ -19,6 +19,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\Release\</OutputPath>
@@ -29,6 +30,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Examples/HelloWorld/CSharp/Program.cs
+++ b/Examples/HelloWorld/CSharp/Program.cs
@@ -4,6 +4,10 @@ using System.Collections.Generic;
 
 using ArrayFire;
 
+// If using Visual Studio 2015 you can uncomment the following lines and type Sin() instead of Arith.Sin(), Seq() instead of Util.Seq(), and so on.
+// using static ArrayFire.Arith;
+// using static ArrayFire.Util;
+
 namespace CSharpTesting
 {
     class Program
@@ -21,6 +25,15 @@ namespace CSharpTesting
             Util.Print(arr3, "arr1 + arr2");
             Util.Print(arr4, "arr1 * arr2 (matrix product)");
             Util.Print(arr5, "Sin(arr1) + Cos(arr2)");
+
+            // new! indexing:    
+            Util.Print(arr1[Util.Span, 0], "arr1's first column");
+            Util.Print(arr1.Cols(0, 0), "arr1's first row (again)");
+            var corner = arr1[Util.Seq(0, 1), Util.Seq(0, 1)];
+            Util.Print(corner, "arr1's top-left 2x2 corner");
+            arr2[Util.Seq(1, 2), Util.Seq(1, 2)] = corner;
+            Util.Print(arr2, "arr2 with botton-right 2x2 corner ovewritten with the previous result");
+
         }
     }
 }

--- a/Examples/HelloWorld/CSharp/Program.cs
+++ b/Examples/HelloWorld/CSharp/Program.cs
@@ -14,7 +14,9 @@ namespace CSharpTesting
     {
         static void Main(string[] args)
         {
-            Device.SetBackend(Backend.CPU);
+            Device.SetBackend(Backend.DEFAULT);
+            Device.PrintInfo();
+
             var arr1 = Data.RandNormal<float>(3, 3);
             var arr2 = Data.RandNormal<float>(3, 3);
             var arr3 = arr1 + arr2;

--- a/Examples/HelloWorld/FSharp/HelloWorld (FSharp).fsproj
+++ b/Examples/HelloWorld/FSharp/HelloWorld (FSharp).fsproj
@@ -58,6 +58,7 @@
     </DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
     <PlatformTarget>x64</PlatformTarget>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0'">

--- a/Examples/HelloWorld/FSharp/Program.fs
+++ b/Examples/HelloWorld/FSharp/Program.fs
@@ -21,4 +21,12 @@ let main argv =
     Util.Print(arr4, "arr1 * arr2 (matrix product)")
     Util.Print(arr5, "sin(arr1) + cos(arr2)");
 
+    // new! indexing:    
+    Util.Print(arr1.[Util.Span, Util.Seq(0,0)], "arr1's first column");
+    Util.Print(arr1.Cols(0, 0), "arr1's first row (again)");
+    let corner = arr1.[Util.Seq(0, 1), Util.Seq(0, 1)]
+    Util.Print(corner, "arr1's top-left 2x2 corner")
+    arr2.[Util.Seq(1, 2), Util.Seq(1, 2)] <- corner
+    Util.Print(arr2, "arr2 with botton-right 2x2 corner ovewritten with the previous result");
+
     0 // return an integer exit code

--- a/Examples/HelloWorld/FSharp/Program.fs
+++ b/Examples/HelloWorld/FSharp/Program.fs
@@ -9,7 +9,9 @@ open ArrayFire
 [<EntryPoint>]
 let main argv = 
 
-    Device.SetBackend(Backend.CPU)
+    Device.SetBackend(Backend.DEFAULT)
+    Device.PrintInfo()
+
     let arr1 = Data.RandNormal<double>(3, 3)
     let arr2 = Data.RandNormal<double>(3, 3)
     let arr3 = arr1 + arr2

--- a/Examples/Unified/CSharp/Unified (CSharp).csproj
+++ b/Examples/Unified/CSharp/Unified (CSharp).csproj
@@ -19,6 +19,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\Release\</OutputPath>
@@ -29,6 +30,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Examples/Unified/FSharp/Unified (FSharp).fsproj
+++ b/Examples/Unified/FSharp/Unified (FSharp).fsproj
@@ -58,6 +58,7 @@
     </DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
     <PlatformTarget>x64</PlatformTarget>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0'">

--- a/README.md
+++ b/README.md
@@ -27,12 +27,10 @@ Contents
 Usage
 ----------------
 
-- TODO
+- Refer to the Examples folder.
 
 Documentation
 ---------------
-- TODO
 
-License
----------------
-- TODO
+- In progress.
+

--- a/Wrapper/ArrayFire.csproj
+++ b/Wrapper/ArrayFire.csproj
@@ -47,11 +47,13 @@
     <Compile Include="Interop\AFBlas.cs" />
     <Compile Include="Interop\AFData.cs" />
     <Compile Include="Interop\AFDevice.cs" />
+    <Compile Include="Interop\AFIndex.cs" />
     <Compile Include="Interop\AFLapack.cs" />
     <Compile Include="Interop\AFSignal.cs" />
     <Compile Include="Interop\AFStatistics.cs" />
     <Compile Include="Interop\AFUtil.cs" />
-    <Compile Include="Interop\Enums.cs" />
+    <Compile Include="Interop\enums.cs" />
+    <Compile Include="Interop\types.cs" />
     <Compile Include="enums.cs" />
     <Compile Include="Matrix.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Wrapper/ArrayFire.csproj
+++ b/Wrapper/ArrayFire.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Interop\AFData.cs" />
     <Compile Include="Interop\AFDevice.cs" />
     <Compile Include="Interop\AFIndex.cs" />
+    <Compile Include="Interop\AFInternal.cs" />
     <Compile Include="Interop\AFLapack.cs" />
     <Compile Include="Interop\AFSignal.cs" />
     <Compile Include="Interop\AFStatistics.cs" />

--- a/Wrapper/ArrayFire.csproj
+++ b/Wrapper/ArrayFire.csproj
@@ -18,6 +18,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\Release\</OutputPath>
@@ -27,6 +28,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Wrapper/Data.cs
+++ b/Wrapper/Data.cs
@@ -56,137 +56,137 @@ namespace ArrayFire
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Array CreateArray($2[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.$1)); return new Array(ptr); }
 #else
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(bool[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.b8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(bool[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.b8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(bool[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.b8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(bool[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.b8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(bool[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.b8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(bool[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.b8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(bool[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.b8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(bool[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.b8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(Complex[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.c64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(Complex[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.c64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(Complex[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.c64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(Complex[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.c64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(Complex[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.c64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(Complex[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.c64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(Complex[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.c64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(Complex[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.c64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(float[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.f32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(float[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.f32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(float[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.f32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(float[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.f32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(float[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.f32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(float[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.f32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(float[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.f32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(float[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.f32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(double[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.f64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(double[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.f64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(double[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.f64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(double[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.f64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(double[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.f64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(double[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.f64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(double[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.f64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(double[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.f64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(int[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.s32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(int[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.s32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(int[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.s32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(int[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.s32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(int[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.s32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(int[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.s32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(int[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.s32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(int[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.s32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(long[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.s64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(long[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.s64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(long[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.s64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(long[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.s64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(long[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.s64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(long[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.s64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(long[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.s64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(long[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.s64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(uint[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(uint[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(uint[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(uint[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(uint[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(uint[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(uint[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u32)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(uint[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u32)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ulong[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ulong[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ulong[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ulong[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ulong[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ulong[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ulong[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u64)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ulong[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u64)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(byte[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(byte[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(byte[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(byte[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(byte[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(byte[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(byte[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u8)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(byte[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u8)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(short[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.s16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(short[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.s16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(short[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.s16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(short[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.s16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(short[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.s16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(short[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.s16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(short[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.s16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(short[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.s16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ushort[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ushort[] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.Length }, af_dtype.u16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ushort[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ushort[,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1) }, af_dtype.u16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ushort[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ushort[,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2) }, af_dtype.u16)); return new Array(ptr); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Array CreateArray(ushort[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u16)); return new Array(ptr); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array CreateArray(ushort[,,,] data) { IntPtr ptr; Internal.VERIFY(AFArray.af_create_array(out ptr, data, (uint)data.Rank, new long[] { data.GetLength(0), data.GetLength(1), data.GetLength(2), data.GetLength(3) }, af_dtype.u16)); return new Array(ptr); }
 #endif
 		#endregion
 
@@ -207,137 +207,137 @@ namespace ArrayFire
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteArray(Array arr, $2[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 #else
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, bool[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, bool[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, bool[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, bool[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, bool[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, bool[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, bool[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, bool[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, Complex[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, Complex[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, Complex[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, Complex[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, Complex[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, Complex[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, Complex[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, Complex[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, float[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, float[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, float[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, float[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, float[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, float[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, float[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, float[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, double[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, double[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, double[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, double[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, double[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, double[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, double[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, double[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, int[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, int[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, int[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, int[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, int[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, int[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, int[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, int[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, long[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, long[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, long[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, long[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, long[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, long[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, long[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, long[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, uint[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, uint[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, uint[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, uint[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, uint[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, uint[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, uint[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, uint[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ulong[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ulong[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ulong[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ulong[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ulong[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ulong[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ulong[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ulong[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, byte[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, byte[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, byte[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, byte[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, byte[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, byte[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, byte[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, byte[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, short[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, short[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, short[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, short[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, short[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, short[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, short[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, short[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ushort[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ushort[] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ushort[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ushort[,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ushort[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ushort[,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void WriteArray(Array arr, ushort[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteArray(Array arr, ushort[,,,] data) { Internal.VERIFY(AFArray.af_write_array(arr._ptr, data, Internal.sizeOfArray(data), af_source.afHost)); }
 #endif
 		#endregion
 
@@ -506,6 +506,16 @@ namespace ArrayFire
 			Internal.VERIFY(AFArith.af_cast(out ptr, arr._ptr, Internal.toDType<X>()));
 			return new Array(ptr);
 		}
-		#endregion
-	}
+        #endregion
+
+        #region Copying
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array Copy(Array arr)
+        {
+            IntPtr ptr;
+            Internal.VERIFY(AFArray.af_copy_array(out ptr, arr._ptr));
+            return new Array(ptr);
+        }
+        #endregion
+    }
 }

--- a/Wrapper/Device.cs
+++ b/Wrapper/Device.cs
@@ -45,6 +45,13 @@ namespace ArrayFire
             Internal.VERIFY(AFBackend.af_set_backend((af_backend)backend));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetDevice(int device)
+        {
+            Internal.VERIFY(AFDevice.af_set_device(device));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void PrintInfo()
         {
             Internal.VERIFY(AFDevice.af_info());
@@ -57,6 +64,16 @@ namespace ArrayFire
                 uint res;
                 Internal.VERIFY(AFBackend.af_get_backend_count(out res));
                 return (int)res;
+            }
+        }
+
+        public static int DeviceCount
+        {
+            get
+            {
+                int res;
+                Internal.VERIFY(AFDevice.af_get_device_count(out res));
+                return res;
             }
         }
     }

--- a/Wrapper/Interop/AFBackend.cs
+++ b/Wrapper/Interop/AFBackend.cs
@@ -17,5 +17,17 @@ namespace ArrayFire.Interop
 
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
 		public static extern af_err af_get_backend_count(out uint num_backends);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_get_available_backends(out int backends);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_get_backend_id(out af_backend backend, IntPtr array_in);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_get_active_backend(out af_backend backend);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_get_device_id(out int device, IntPtr array_in);
 	}
 }

--- a/Wrapper/Interop/AFDevice.cs
+++ b/Wrapper/Interop/AFDevice.cs
@@ -18,6 +18,10 @@ namespace ArrayFire.Interop
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
 		public static extern af_err af_init();
 
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_info_string(???char** str???, bool verbose); */
+
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
 		public static extern af_err af_device_info([Out] StringBuilder d_name, [Out] StringBuilder d_platform, [Out] StringBuilder d_toolkit, [Out] StringBuilder d_compute);
 
@@ -39,10 +43,6 @@ namespace ArrayFire.Interop
 		/* not yet supported:
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
 		public static extern af_err af_alloc_device(???void **ptr???, long dim_bytes); */
-
-		/* not yet supported:
-		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
-		public static extern af_err af_alloc_pinned(???void **ptr???, long dim_bytes); */
 
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
 		public static extern af_err af_free_device([Out] bool[] ptr);
@@ -176,6 +176,10 @@ namespace ArrayFire.Interop
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
 		public static extern af_err af_free_device([Out] ushort[,,,] ptr);
 
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_alloc_pinned(???void **ptr???, long dim_bytes); */
+
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
 		public static extern af_err af_free_pinned([Out] bool[] ptr);
 
@@ -307,6 +311,142 @@ namespace ArrayFire.Interop
 
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
 		public static extern af_err af_free_pinned([Out] ushort[,,,] ptr);
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_alloc_host(???void **ptr???, long dim_bytes); */
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] bool[] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] Complex[] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] float[] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] double[] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] int[] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] long[] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] uint[] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] ulong[] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] byte[] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] short[] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] ushort[] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] bool[,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] Complex[,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] float[,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] double[,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] int[,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] long[,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] uint[,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] ulong[,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] byte[,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] short[,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] ushort[,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] bool[,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] Complex[,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] float[,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] double[,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] int[,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] long[,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] uint[,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] ulong[,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] byte[,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] short[,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] ushort[,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] bool[,,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] Complex[,,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] float[,,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] double[,,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] int[,,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] long[,,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] uint[,,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] ulong[,,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] byte[,,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] short[,,,] ptr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_free_host([Out] ushort[,,,] ptr);
 
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
 		public static extern af_err af_device_array(out IntPtr array_arr, [In] bool[] data, uint ndims, [In] long[] dim_dims, af_dtype type);
@@ -444,6 +584,9 @@ namespace ArrayFire.Interop
 		public static extern af_err af_device_mem_info(out UIntPtr size_alloc_bytes, out UIntPtr size_alloc_buffers, out UIntPtr size_lock_bytes, out UIntPtr size_lock_buffers);
 
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_print_mem_info(string msg, int device_id);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
 		public static extern af_err af_device_gc();
 
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
@@ -457,6 +600,12 @@ namespace ArrayFire.Interop
 
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
 		public static extern af_err af_unlock_device_ptr(IntPtr array_arr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_lock_array(IntPtr array_arr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_unlock_array(IntPtr array_arr);
 
 		/* not yet supported:
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]

--- a/Wrapper/Interop/AFIndex.cs
+++ b/Wrapper/Interop/AFIndex.cs
@@ -1,0 +1,52 @@
+// This file was automatically generated using the AutoGenTool project
+// If possible, edit the tool instead of editing this file directly
+
+using System;
+using System.Text;
+using System.Numerics;
+using System.Security;
+using System.Runtime.InteropServices;
+
+namespace ArrayFire.Interop
+{
+	[SuppressUnmanagedCodeSecurity]
+	public static class AFIndex
+	{
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_index(out IntPtr array_out, IntPtr array_in, uint ndims, [In] af_seq[] index);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_lookup(out IntPtr array_out, IntPtr array_in, IntPtr array_indices, uint dim);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_assign_seq(ref IntPtr array_out, IntPtr array_lhs, uint ndims, [In] af_seq[] indices, IntPtr array_rhs);
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_index_gen(out IntPtr array_out, IntPtr array_in, long dim_ndims, ???const af_index_t* indices???); */
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_assign_gen(out IntPtr array_out, IntPtr array_lhs, long dim_ndims, ???const af_index_t* indices???, IntPtr array_rhs); */
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_indexers(???af_index_t** indexers???); */
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_set_array_indexer(out ???af_index_t??? indexer, IntPtr array_idx, long dim_dim); */
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_set_seq_indexer(out ???af_index_t??? indexer, [In] af_seq[] idx, long dim_dim, bool is_batch); */
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_set_seq_param_indexer(out ???af_index_t??? indexer, double begin, double end, double step, long dim_dim, bool is_batch); */
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_release_indexers(out ???af_index_t??? indexers); */
+	}
+}

--- a/Wrapper/Interop/AFInternal.cs
+++ b/Wrapper/Interop/AFInternal.cs
@@ -1,0 +1,163 @@
+// This file was automatically generated using the AutoGenTool project
+// If possible, edit the tool instead of editing this file directly
+
+using System;
+using System.Text;
+using System.Numerics;
+using System.Security;
+using System.Runtime.InteropServices;
+
+namespace ArrayFire.Interop
+{
+	[SuppressUnmanagedCodeSecurity]
+	public static class AFInternal
+	{
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] bool[] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] Complex[] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] float[] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] double[] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] int[] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] long[] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] uint[] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] ulong[] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] byte[] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] short[] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] ushort[] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] bool[,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] Complex[,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] float[,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] double[,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] int[,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] long[,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] uint[,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] ulong[,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] byte[,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] short[,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] ushort[,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] bool[,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] Complex[,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] float[,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] double[,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] int[,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] long[,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] uint[,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] ulong[,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] byte[,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] short[,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] ushort[,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] bool[,,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] Complex[,,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] float[,,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] double[,,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] int[,,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] long[,,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] uint[,,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] ulong[,,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] byte[,,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] short[,,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_create_strided_array(out IntPtr array_arr, [In] ushort[,,,] data, long dim_offset, uint ndims, [In] long[] dim_dims, [In] long[] dim_strides, af_dtype ty, af_source location);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_get_strides(out long dim_s0, out long dim_s1, out long dim_s2, out long dim_s3, IntPtr array_arr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_get_offset(out long dim_offset, IntPtr array_arr);
+
+		/* not yet supported:
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_get_raw_ptr(???void **ptr???, IntPtr array_arr); */
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_is_linear(out bool result, IntPtr array_arr);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_is_owner(out bool result, IntPtr array_arr);
+	}
+}

--- a/Wrapper/Interop/AFLapack.cs
+++ b/Wrapper/Interop/AFLapack.cs
@@ -53,5 +53,8 @@ namespace ArrayFire.Interop
 
 		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
 		public static extern af_err af_norm(out double output, IntPtr array_in, af_norm_type type, double p, double q);
+
+		[DllImport(af_config.dll, ExactSpelling = true, SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+		public static extern af_err af_is_lapack_available(out bool output);
 	}
 }

--- a/Wrapper/Interop/enums.cs
+++ b/Wrapper/Interop/enums.cs
@@ -66,6 +66,13 @@ namespace ArrayFire.Interop
 		AF_ERR_BATCH          = 207,
 
 
+		// #if AF_API_VERSION >= 33
+		///
+		/// Input does not belong to the current device.
+		///
+		AF_ERR_DEVICE         = 208,
+		// #endif
+
 		// 300-399 Errors for missing software features
 
 		///
@@ -78,10 +85,12 @@ namespace ArrayFire.Interop
 		///
 		AF_ERR_NOT_CONFIGURED = 302,
 
+		// #if AF_API_VERSION >= 32
 		///
 		/// This build of ArrayFire is not compiled with "nonfree" algorithms
 		///
-		AFF_ERR_NONFREE       = 303,
+		AF_ERR_NONFREE        = 303,
+		// #endif
 
 		// 400-499 Errors for missing hardware features
 
@@ -97,8 +106,27 @@ namespace ArrayFire.Interop
 		AF_ERR_NO_GFX         = 402,
 
 		// 500-599 Errors specific to heterogenous API
+
+		// #if AF_API_VERSION >= 32
+		///
+		/// There was an error when loading the libraries
+		///
 		AF_ERR_LOAD_LIB       = 501,
+		// #endif
+
+		// #if AF_API_VERSION >= 32
+		///
+		/// There was an error when loading the symbols
+		///
 		AF_ERR_LOAD_SYM       = 502,
+		// #endif
+
+		// #if AF_API_VERSION >= 32
+		///
+		/// There was a mismatch between the input array and the active backend
+		///
+		AF_ERR_ARR_BKND_MISMATCH    = 503,
+		// #endif
 
 		// 900-999 Errors from upstream libraries and runtimes
 
@@ -128,6 +156,8 @@ namespace ArrayFire.Interop
 		u64,    ///< 64-bit unsigned integral values
 		// #if AF_API_VERSION >= 32
 		s16,    ///< 16-bit signed integral values
+		// #endif
+		// #if AF_API_VERSION >= 32
 		u16,    ///< 16-bit unsigned integral values
 		// #endif
 	}
@@ -218,7 +248,9 @@ namespace ArrayFire.Interop
 		AF_GRAY = 0, ///< Grayscale
 		AF_RGB,      ///< 3-channel RGB
 		AF_HSV,      ///< 3-channel HSV
+		// #if AF_API_VERSION >= 31
 		AF_YCbCr     ///< 3-channel YCbCr
+		// #endif
 	}
 
 	public enum af_mat_prop
@@ -279,16 +311,34 @@ namespace ArrayFire.Interop
 		AF_FIF_RAW          = 34    ///< FreeImage Enum for RAW Camera Image File
 	}
 
+	public enum af_homography_type
+	{
+		AF_HOMOGRAPHY_RANSAC = 0,   ///< Computes homography using RANSAC
+		AF_HOMOGRAPHY_LMEDS  = 1    ///< Computes homography using Least Median of Squares
+	}
+
 	public enum af_backend
 	{
 		AF_BACKEND_DEFAULT = 0,  ///< Default backend order: OpenCL -> CUDA -> CPU
 		AF_BACKEND_CPU     = 1,  ///< CPU a.k.a sequential algorithms
 		AF_BACKEND_CUDA    = 2,  ///< CUDA Compute Backend
-		AF_BACKEND_OPENCL  = 3,  ///< OpenCL Compute Backend
+		AF_BACKEND_OPENCL  = 4,  ///< OpenCL Compute Backend
 	}
 
 	public enum af_someenum_t
 	{
 		AF_ID = 0
+	}
+
+	public enum af_marker_type
+	{
+		AF_MARKER_NONE         = 0,
+		AF_MARKER_POINT        = 1,
+		AF_MARKER_CIRCLE       = 2,
+		AF_MARKER_SQUARE       = 3,
+		AF_MARKER_TRIANGLE     = 4,
+		AF_MARKER_CROSS        = 5,
+		AF_MARKER_PLUS         = 6,
+		AF_MARKER_STAR         = 7
 	}
 }

--- a/Wrapper/Interop/enums.cs
+++ b/Wrapper/Interop/enums.cs
@@ -9,11 +9,6 @@ using System.Runtime.InteropServices;
 
 namespace ArrayFire.Interop
 {
-	internal static class af_config // put here for convenience
-	{
-		internal const string dll = @"af";
-	}
-
 	public enum af_err
 	{
 		///

--- a/Wrapper/Interop/types.cs
+++ b/Wrapper/Interop/types.cs
@@ -1,0 +1,37 @@
+// This file was automatically generated using the AutoGenTool project
+// If possible, edit the tool instead of editing this file directly
+
+using System;
+using System.Text;
+using System.Numerics;
+using System.Security;
+using System.Runtime.InteropServices;
+
+namespace ArrayFire.Interop
+{
+	internal static class af_config
+	{
+		internal const string dll = @"af";
+	}
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct af_seq
+    {
+        public af_seq(double begin, double end, double step)
+        {
+            this.begin = begin;
+            this.end = end;
+            this.step = step;
+        }
+
+        // the C-API uses doubles so we have to do the same
+        public double begin;
+        public double end;
+        public double step;
+
+        public static readonly af_seq Span = new af_seq(1, 1, 0); // as defined in include/af/seq.h
+
+        // implicit conversion from a number, only works in C# (not in F#)
+        public static implicit operator af_seq(double begin) { return new af_seq(begin, begin, 1); }
+    }
+}

--- a/Wrapper/Util.cs
+++ b/Wrapper/Util.cs
@@ -51,6 +51,20 @@ namespace ArrayFire
 		{
 			Internal.VERIFY(AFUtil.af_print_array_gen(name, arr._ptr, precision));
 		}
-		#endregion
-	}
+        #endregion
+
+        #region Sequences
+        public static readonly af_seq Span = af_seq.Span; // for convenience
+
+        public static af_seq Seq(double begin, double end, double step = 1)
+        {
+            return new af_seq(begin, end, step);
+        }
+
+        public static af_seq Seq(int begin, int end, int step = 1)
+        {
+            return new af_seq(begin, end, step);
+        }
+        #endregion
+    }
 }


### PR DESCRIPTION
Summary:

The *HelloWorld* examples have a few new lines showing the indexing functionality for both C# and F#

**Array.cs**: has a new indexing operator **[]**
**Util.cs**: new **Seq()** and **Span** members
**Data.cs**: new **Copy()** method (which was missing)

Inside the *Interop* folder there's a new file (**AFIndex.cs**) and there's a new class **af_seq**.

*AutoGenTool* changes can be pretty much ignored since they are only for development purposes (code/interop generation).