### PR TITLE
Expose array-scalar binary operators and some array and reduction functions

### DIFF
--- a/src/Wrapper/Algorithm.cs
+++ b/src/Wrapper/Algorithm.cs
@@ -52,41 +52,11 @@ namespace ArrayFire
         {
             af_dtype dtype = Internal.toDType<T>();
             double r, i;
-            switch(dtype)
-            {
-                case af_dtype.f32:
-                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
-                    return (float)r;
-                case af_dtype.f64:
-                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
-                    return (double)r;
-                case af_dtype.s32:
-                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
-                    return (int)r;
-                case af_dtype.s64:
-                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
-                    return (long)r;
-                case af_dtype.u32:
-                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
-                    return (uint)r;
-                case af_dtype.u64:
-                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
-                    return (ulong)r;
-                case af_dtype.u8:
-                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
-                    return (byte)r;
-                case af_dtype.s16:
-                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
-                    return (short)r;
-                case af_dtype.u16:
-                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
-                    return (ushort)r;
-                case af_dtype.c32:
-                case af_dtype.c64:
-                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out i, arr._ptr));
-                    return new Complex(r, i);
-                default:
-                    throw new NotSupportedException("Data type not supported");
+            Internal.VERIFY(AFAlgorithm.af_min_all(out r, out i, arr._ptr));
+            if (dtype == af_dtype.c32 || dtype == af_dtype.c64) {
+                return new Complex(r, i);
+            } else {
+                return Convert.ChangeType(r, Internal.toClrType(dtype));
             }
         }
 
@@ -95,41 +65,11 @@ namespace ArrayFire
         {
             af_dtype dtype = Internal.toDType<T>();
             double r, i;
-            switch(dtype)
-            {
-                case af_dtype.f32:
-                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
-                    return (float)r;
-                case af_dtype.f64:
-                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
-                    return (double)r;
-                case af_dtype.s32:
-                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
-                    return (int)r;
-                case af_dtype.s64:
-                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
-                    return (long)r;
-                case af_dtype.u32:
-                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
-                    return (uint)r;
-                case af_dtype.u64:
-                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
-                    return (ulong)r;
-                case af_dtype.u8:
-                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
-                    return (byte)r;
-                case af_dtype.s16:
-                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
-                    return (short)r;
-                case af_dtype.u16:
-                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
-                    return (ushort)r;
-                case af_dtype.c32:
-                case af_dtype.c64:
-                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out i, arr._ptr));
-                    return new Complex(r, i);
-                default:
-                    throw new NotSupportedException("Data type not supported");
+            Internal.VERIFY(AFAlgorithm.af_max_all(out r, out i, arr._ptr));
+            if (dtype == af_dtype.c32 || dtype == af_dtype.c64) {
+                return new Complex(r, i);
+            } else {
+                return Convert.ChangeType(r, Internal.toClrType(dtype));
             }
         }
         // TODO: Add the other algorithms

--- a/src/Wrapper/Algorithm.cs
+++ b/src/Wrapper/Algorithm.cs
@@ -47,6 +47,91 @@ namespace ArrayFire
             return new Complex(r, i);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static object MinAll<T>(Array arr)
+        {
+            af_dtype dtype = Internal.toDType<T>();
+            double r, i;
+            switch(dtype)
+            {
+                case af_dtype.f32:
+                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
+                    return (float)r;
+                case af_dtype.f64:
+                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
+                    return (double)r;
+                case af_dtype.s32:
+                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
+                    return (int)r;
+                case af_dtype.s64:
+                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
+                    return (long)r;
+                case af_dtype.u32:
+                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
+                    return (uint)r;
+                case af_dtype.u64:
+                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
+                    return (ulong)r;
+                case af_dtype.u8:
+                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
+                    return (byte)r;
+                case af_dtype.s16:
+                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
+                    return (short)r;
+                case af_dtype.u16:
+                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out _, arr._ptr));
+                    return (ushort)r;
+                case af_dtype.c32:
+                case af_dtype.c64:
+                    Internal.VERIFY(AFAlgorithm.af_min_all(out r, out i, arr._ptr));
+                    return new Complex(r, i);
+                default:
+                    throw new NotSupportedException("Data type not supported");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static object MaxAll<T>(Array arr)
+        {
+            af_dtype dtype = Internal.toDType<T>();
+            double r, i;
+            switch(dtype)
+            {
+                case af_dtype.f32:
+                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
+                    return (float)r;
+                case af_dtype.f64:
+                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
+                    return (double)r;
+                case af_dtype.s32:
+                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
+                    return (int)r;
+                case af_dtype.s64:
+                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
+                    return (long)r;
+                case af_dtype.u32:
+                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
+                    return (uint)r;
+                case af_dtype.u64:
+                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
+                    return (ulong)r;
+                case af_dtype.u8:
+                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
+                    return (byte)r;
+                case af_dtype.s16:
+                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
+                    return (short)r;
+                case af_dtype.u16:
+                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out _, arr._ptr));
+                    return (ushort)r;
+                case af_dtype.c32:
+                case af_dtype.c64:
+                    Internal.VERIFY(AFAlgorithm.af_max_all(out r, out i, arr._ptr));
+                    return new Complex(r, i);
+                default:
+                    throw new NotSupportedException("Data type not supported");
+            }
+        }
         // TODO: Add the other algorithms
     }
 }

--- a/src/Wrapper/Array.cs
+++ b/src/Wrapper/Array.cs
@@ -30,6 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 using System;
+using System.Numerics;
 using System.Threading;
 using System.Runtime.CompilerServices;
 
@@ -163,6 +164,881 @@ namespace ArrayFire
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static Array operator ^(Array lhs, Array rhs) { IntPtr ptr; Internal.VERIFY(AFArith.af_bitxor(out ptr, lhs._ptr, rhs._ptr, false)); return new Array(ptr); }
 #endif
+
+#if _
+for (\w+) in
+    bool Complex float double int long uint ulong byte short ushort
+do
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Array lhs, $1 rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<$1>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Array lhs, $1 rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<$1>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Array lhs, $1 rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<$1>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Array lhs, $1 rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<$1>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+#else
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Array lhs, bool rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<bool>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Array lhs, bool rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<bool>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Array lhs, bool rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<bool>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Array lhs, bool rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<bool>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Array lhs, Complex rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<Complex>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Array lhs, Complex rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<Complex>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Array lhs, Complex rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<Complex>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Array lhs, Complex rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<Complex>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Array lhs, float rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<float>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Array lhs, float rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<float>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Array lhs, float rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<float>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Array lhs, float rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<float>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Array lhs, double rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<double>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Array lhs, double rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<double>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Array lhs, double rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<double>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Array lhs, double rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<double>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Array lhs, int rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<int>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Array lhs, int rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<int>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Array lhs, int rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<int>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Array lhs, int rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<int>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Array lhs, long rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<long>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Array lhs, long rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<long>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Array lhs, long rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<long>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Array lhs, long rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<long>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Array lhs, uint rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<uint>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Array lhs, uint rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<uint>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Array lhs, uint rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<uint>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Array lhs, uint rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<uint>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Array lhs, ulong rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ulong>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Array lhs, ulong rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ulong>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Array lhs, ulong rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ulong>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Array lhs, ulong rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ulong>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Array lhs, byte rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<byte>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Array lhs, byte rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<byte>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Array lhs, byte rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<byte>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Array lhs, byte rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<byte>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Array lhs, short rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<short>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Array lhs, short rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<short>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Array lhs, short rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<short>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Array lhs, short rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<short>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Array lhs, ushort rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ushort>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Array lhs, ushort rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ushort>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Array lhs, ushort rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ushort>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Array lhs, ushort rhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ushort>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+#endif
+
+#if _
+for (\w+) in
+    bool Complex float double int long uint ulong byte short ushort
+do
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +($1 rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<$1>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -($1 rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<$1>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *($1 rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<$1>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /($1 rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<$1>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+#else
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(bool rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<bool>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(bool rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<bool>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(bool rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<bool>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(bool rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<bool>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(Complex rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<Complex>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(Complex rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<Complex>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(Complex rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<Complex>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(Complex rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<Complex>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(float rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<float>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(float rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<float>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(float rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<float>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(float rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<float>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(double rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<double>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(double rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<double>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(double rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<double>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(double rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<double>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(int rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<int>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(int rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<int>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(int rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<int>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(int rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<int>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(long rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<long>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(long rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<long>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(long rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<long>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(long rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<long>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(uint rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<uint>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(uint rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<uint>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(uint rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<uint>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(uint rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<uint>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(ulong rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ulong>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(ulong rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ulong>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(ulong rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ulong>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(ulong rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ulong>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(byte rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<byte>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(byte rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<byte>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(byte rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<byte>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(byte rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<byte>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(short rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<short>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(short rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<short>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(short rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<short>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(short rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<short>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator +(ushort rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ushort>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_add(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator -(ushort rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ushort>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_sub(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator *(ushort rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ushort>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_mul(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array operator /(ushort rhs, Array lhs)
+    {
+        IntPtr ptr;
+        var rhs_array = Data.Constant<ushort>(rhs, lhs.Dimensions);
+        Internal.VERIFY(AFArith.af_div(out ptr, lhs._ptr, rhs_array._ptr, false));
+        return new Array(ptr);
+    }
+#endif
+
 		#endregion
 
 		#region IDisposable Support

--- a/src/Wrapper/Data.cs
+++ b/src/Wrapper/Data.cs
@@ -517,5 +517,35 @@ namespace ArrayFire
             return new Array(ptr);
         }
         #endregion
+
+        #region Moddims
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array Moddims(Array arr, params int[] dims)
+        {
+            IntPtr ptr;
+            Internal.VERIFY(AFData.af_moddims(out ptr, arr._ptr, (uint) dims.Length , Internal.toLongArray(dims)));
+            return new Array(ptr);
+        }
+        #endregion
+
+        #region Flat
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array Flat(Array arr)
+        {
+            IntPtr ptr;
+            Internal.VERIFY(AFData.af_flat(out ptr, arr._ptr));
+            return new Array(ptr);
+        }
+        #endregion
+
+        #region Flip
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array Flip(Array arr, uint dim)
+        {
+            IntPtr ptr;
+            Internal.VERIFY(AFData.af_flip(out ptr, arr._ptr, dim));
+            return new Array(ptr);
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Currently, only array-array binary arithmetic operations (`+, -, *, /`) are supported. This aims to expose the array-scalar (and vice versa) operations too.

These functions are exposed too:
- Flat
- Flip
- Moddims
- MinAll
- MaxAll

Feedback welcome!
